### PR TITLE
stop audio when leaving current page

### DIFF
--- a/src/internals/hooks/UseSound.ts
+++ b/src/internals/hooks/UseSound.ts
@@ -25,6 +25,15 @@ const useSound: UseSoundHookSignature = (soundFilePath: string) => {
     }
   }, [isPlaying]);
 
+  React.useEffect(() => {    
+    return () => {
+      if (soundFileHandle.current) {
+        soundFileHandle.current.pause();
+        soundFileHandle.current.currentTime = 0;
+      }
+    }
+  }, []);
+
   return [isPlaying, setPlaying];
 };
 


### PR DESCRIPTION
Hello,

this is a potential fix for this issue: https://github.com/flogy/gatsby-mdx-tts/issues/15

It simply stops the audio playback on unmount.